### PR TITLE
Updated surface-controllers.md

### DIFF
--- a/Reference/Routing/surface-controllers.md
+++ b/Reference/Routing/surface-controllers.md
@@ -96,6 +96,8 @@ Since they get routed via an MVC area, your views should be placed in the follow
 * `~/App_Plugins/{areaname}/Views/{controllername}/`
 * `~/App_Plugins/{areaname}/Views/Shared/`
 
+The controller itself should not be placed in the App_Plugins folder, as files in this folder are not compiled by Umbraco. Either build your controller to a dll file and place it in bin, or put the .cs file in the App_Code folder.
+
 #### Protecting surface controller routes
 
 If you only want a surface controller action to be available when it's used within an Umbraco form and not from the auto-routed URL, you can add the `[ValidateUmbracoFormRouteString]` attribute to the action method. This can be especially useful for plugin based controllers, as this makes sure the actions can only be activated whenever it's used within the website.


### PR DESCRIPTION
Added information regarding where to put controllers in a plugin based controller. It was not obvious that it cannot go in the App_plugins folder too, which took me a few days to figure out why.

If there is a link to a page in the documentation where this is detailed, I will be happy to add that too, but I cannot find it.